### PR TITLE
Custom storybook babel should exist within .storybook

### DIFF
--- a/.storybook/.babelrc
+++ b/.storybook/.babelrc
@@ -1,0 +1,12 @@
+ {
+    "presets": ["@babel/preset-react", "@babel/preset-env"],
+    "plugins": ["inline-react-svg",  [
+        "module-resolver",
+        {
+          "alias": {
+            "@commons-ui/core": "./packages/core"
+          }
+        }
+      ]]
+  }
+  


### PR DESCRIPTION
## Description

https://storybook.js.org/docs/configurations/custom-babel-config/

This will ensure that `yarn deploy` storybook will resolve modules while `yarn release` will respect the module names `@commons-ui/*`.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
