### PR TITLE
[Hotfix] Footer Stay in Touch component

### DIFF
--- a/packages/core/src/Footer/StayInTouch.js
+++ b/packages/core/src/Footer/StayInTouch.js
@@ -41,35 +41,17 @@ function StayInTouch({ support, socialMedia, ...props }) {
             />
           </A>
         </div>
-        {socialMedia.map(
-          (media) =>
-            console.log("BOOMM", { media }) || (
-              <div className={classes.iconContainer}>
-                <A href={media.url} className={classes.links}>
-                  <img
-                    src={media.image.url}
-                    alt={media.image.alt}
-                    className={classes.icon}
-                  />
-                </A>
-              </div>
-            )
-        )}
-        {/* <div className={classes.iconContainer}>
-          <A href={socialMedia.facebook.link} className={classes.links}>
-            <socialMedia.facebook.component alt="" className={classes.icon} />
-          </A>
-        </div>
-        <div className={classes.iconContainer}>
-          <A href={socialMedia.medium.link} className={classes.links}>
-            <socialMedia.medium.component alt="" className={classes.icon} />
-          </A>
-        </div>
-        <div className={classes.iconContainer}>
-          <A href={socialMedia.linkedin.link} className={classes.links}>
-            <socialMedia.linkedin.component alt="" className={classes.icon} />
-          </A>
-        </div> */}
+        {socialMedia.map((media) => (
+          <div className={classes.iconContainer}>
+            <A href={media.url} className={classes.links}>
+              <img
+                src={media.image.url}
+                alt={media.image.alt}
+                className={classes.icon}
+              />
+            </A>
+          </div>
+        ))}
       </Grid>
     </div>
   );

--- a/packages/core/src/Footer/StayInTouch.js
+++ b/packages/core/src/Footer/StayInTouch.js
@@ -19,29 +19,43 @@ const useStyles = makeStyles({
   links: {},
 });
 
-function StayInTouch({ settings: { support, socialMedia }, ...props }) {
+function StayInTouch({ support, socialMedia, ...props }) {
   const classes = useStyles(props);
+
   return (
     <div className={classes.root}>
       <Grid container justify="flex-start" alignItems="center">
         <Typography>Stay in touch with us @&nbsp;</Typography>
         <div className={classes.iconContainer}>
           <A
-            href={`mailto:${support.hello}`}
+            href={`mailto:${support.email}`}
             className={classes.links}
             target="_blank"
             rel="noopener noreferrer"
           >
             {" "}
-            <support.component alt="" className={classes.icon} />
+            <img
+              src={support.image.url}
+              alt={support.image.alt}
+              className={classes.icon}
+            />
           </A>
         </div>
-        <div className={classes.iconContainer}>
-          <A href={socialMedia.twitter.link} className={classes.links}>
-            <socialMedia.twitter.component alt="" className={classes.icon} />
-          </A>
-        </div>
-        <div className={classes.iconContainer}>
+        {socialMedia.map(
+          (media) =>
+            console.log("BOOMM", { media }) || (
+              <div className={classes.iconContainer}>
+                <A href={media.url} className={classes.links}>
+                  <img
+                    src={media.image.url}
+                    alt={media.image.alt}
+                    className={classes.icon}
+                  />
+                </A>
+              </div>
+            )
+        )}
+        {/* <div className={classes.iconContainer}>
           <A href={socialMedia.facebook.link} className={classes.links}>
             <socialMedia.facebook.component alt="" className={classes.icon} />
           </A>
@@ -55,37 +69,29 @@ function StayInTouch({ settings: { support, socialMedia }, ...props }) {
           <A href={socialMedia.linkedin.link} className={classes.links}>
             <socialMedia.linkedin.component alt="" className={classes.icon} />
           </A>
-        </div>
+        </div> */}
       </Grid>
     </div>
   );
 }
 
 StayInTouch.propTypes = {
-  settings: PropTypes.shape({
-    support: PropTypes.shape({
-      hello: PropTypes.string.isRequired,
-      component: PropTypes.func.isRequired,
-    }).isRequired,
-    socialMedia: PropTypes.shape({
-      facebook: PropTypes.shape({
-        link: PropTypes.string.isRequired,
-        component: PropTypes.func.isRequired,
-      }).isRequired,
-      linkedin: PropTypes.shape({
-        link: PropTypes.string.isRequired,
-        component: PropTypes.func.isRequired,
-      }).isRequired,
-      medium: PropTypes.shape({
-        link: PropTypes.string.isRequired,
-        component: PropTypes.func.isRequired,
-      }).isRequired,
-      twitter: PropTypes.shape({
-        link: PropTypes.string.isRequired,
-        component: PropTypes.func.isRequired,
-      }).isRequired,
+  support: PropTypes.shape({
+    email: PropTypes.string.isRequired,
+    image: PropTypes.shape({
+      url: PropTypes.string.isRequired,
+      alt: PropTypes.string.isRequired,
     }).isRequired,
   }).isRequired,
+  socialMedia: PropTypes.arrayOf(
+    PropTypes.shape({
+      url: PropTypes.string.isRequired,
+      image: PropTypes.shape({
+        url: PropTypes.string.isRequired,
+        alt: PropTypes.string.isRequired,
+      }).isRequired,
+    }).isRequired
+  ).isRequired,
 };
 
 export default StayInTouch;

--- a/packages/core/src/Footer/index.js
+++ b/packages/core/src/Footer/index.js
@@ -145,7 +145,7 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 function Footer({
-  about: { settings },
+  about: { support, socialMedia },
   firstLinks,
   aboutSection,
   initiativeLogo,
@@ -222,7 +222,8 @@ function Footer({
           <Grid container justify="flex-start" alignItems="flex-start">
             <div className={classes.takwimu}>
               <StayInTouch
-                settings={settings}
+                support={support}
+                socialMedia={socialMedia}
                 classes={{
                   root: classes.stayInTouch,
                   icon: classes.stayInTouchIcon,
@@ -248,7 +249,8 @@ function Footer({
 
 Footer.propTypes = {
   about: PropTypes.shape({
-    settings: PropTypes.shape({}).isRequired,
+    support: PropTypes.shape({}).isRequired,
+    socialMedia: PropTypes.arrayOf(PropTypes.shape({}).isRequired).isRequired,
   }).isRequired,
   firstLinks: PropTypes.shape({}).isRequired,
   aboutSection: PropTypes.shape({}).isRequired,

--- a/stories/footer.stories.js
+++ b/stories/footer.stories.js
@@ -82,17 +82,13 @@ const SOCIAL_MEDIA = {
   ],
 };
 
-storiesOf("Components|Footer", module).add(
-  "Footer",
-  () =>
-    console.log("BOOM", { SOCIAL_MEDIA }) || (
-      <Footer
-        about={SOCIAL_MEDIA}
-        firstLinks={FIRST_LINKS}
-        secondLinks={FIRST_LINKS}
-        aboutSection={ABOUT}
-        initiativeLogo={INITIATIVE_LOGO}
-        CFA={CFA}
-      />
-    )
-);
+storiesOf("Components|Footer", module).add("Footer", () => (
+  <Footer
+    about={SOCIAL_MEDIA}
+    firstLinks={FIRST_LINKS}
+    secondLinks={FIRST_LINKS}
+    aboutSection={ABOUT}
+    initiativeLogo={INITIATIVE_LOGO}
+    CFA={CFA}
+  />
+));

--- a/stories/footer.stories.js
+++ b/stories/footer.stories.js
@@ -5,11 +5,11 @@ import { Footer } from "@commons-ui/core";
 import pulitzer from "./assets/pulitzer.png";
 import cfaLogo from "./assets/cfa.png";
 
-import { ReactComponent as Email } from "./assets/email.svg";
-import { ReactComponent as Facebook } from "./assets/facebook.svg";
-import { ReactComponent as Medium } from "./assets/group-3.svg";
-import { ReactComponent as LinkedIn } from "./assets/group-3-copy.svg";
-import { ReactComponent as Twitter } from "./assets/twitter.svg";
+import Email from "./assets/email.svg";
+import Facebook from "./assets/facebook.svg";
+import Medium from "./assets/group-3.svg";
+import LinkedIn from "./assets/group-3-copy.svg";
+import Twitter from "./assets/twitter.svg";
 
 const FIRST_LINKS = {
   title: "MORE",
@@ -43,39 +43,56 @@ const CFA = {
 };
 
 const SOCIAL_MEDIA = {
-  settings: {
-    support: {
-      hello: "hello@contact.com",
-      component: Email,
-    },
-    socialMedia: {
-      facebook: {
-        link: "https://facebook.com",
-        component: Facebook,
-      },
-      linkedin: {
-        link: "https://linkedin.com",
-        component: LinkedIn,
-      },
-      medium: {
-        link: "https://medium.com",
-        component: Medium,
-      },
-      twitter: {
-        link: "https://twitter.com",
-        component: Twitter,
-      },
+  support: {
+    email: "hello@contact.com",
+    image: {
+      url: Email,
+      alt: "Email",
     },
   },
+  socialMedia: [
+    {
+      url: "https://twitter.com",
+      image: {
+        url: Twitter,
+        alt: "Twitter",
+      },
+    },
+    {
+      url: "https://facebook.com",
+      image: {
+        url: Facebook,
+        alt: "Facebook",
+      },
+    },
+    {
+      url: "https://medium.com",
+      image: {
+        url: Medium,
+        alt: "Medium",
+      },
+    },
+    {
+      url: "https://linkedin.com",
+      image: {
+        url: LinkedIn,
+        alt: "LinkedIn",
+      },
+    },
+  ],
 };
 
-storiesOf("Components|Footer", module).add("Footer", () => (
-  <Footer
-    about={SOCIAL_MEDIA}
-    firstLinks={FIRST_LINKS}
-    secondLinks={FIRST_LINKS}
-    aboutSection={ABOUT}
-    initiativeLogo={INITIATIVE_LOGO}
-    CFA={CFA}
-  />
-));
+storiesOf("Components|Footer", module).add(
+  "Footer",
+  () =>
+    console.log("BOOM", { SOCIAL_MEDIA }) || (
+      <Footer
+        about={SOCIAL_MEDIA}
+        firstLinks={FIRST_LINKS}
+        secondLinks={FIRST_LINKS}
+        aboutSection={ABOUT}
+        initiativeLogo={INITIATIVE_LOGO}
+        CFA={CFA}
+      />
+    )
+);


### PR DESCRIPTION
## Description

 - [x] Remove the old style of passing settings props,
 - [x] Accept *image* (`url` and `alt`) instead of *component*.

NOTE:

We still need to configure Storybook to load `*.svg` using url loader instead of using file loader.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## Screenshots

N/A

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
