### PR TITLE
ListItem

### DIFF
--- a/packages/core/src/ListItem/index.js
+++ b/packages/core/src/ListItem/index.js
@@ -1,0 +1,96 @@
+/* eslint-disable react/no-danger, jsx-a11y/control-has-associated-label */
+import React from "react";
+import { PropTypes } from "prop-types";
+
+import clsx from "clsx";
+
+import { Button, Grid, Typography } from "@material-ui/core";
+
+import useStyles from "./useStyles";
+
+function ListItem({
+  description,
+  image,
+  link,
+  name,
+  onClick,
+  selected,
+  title,
+  ...props
+}) {
+  const classes = useStyles({ ...props, image });
+
+  return (
+    <Grid
+      container
+      direction="column"
+      justify="flex-end"
+      role="button"
+      tabIndex={0}
+      className={classes.root}
+      onClick={onClick}
+      onKeyUp={undefined}
+    >
+      <img
+        alt={image.description || name || title}
+        src={image.url}
+        className={clsx(classes.picture, {
+          [classes.pictureSelected]: selected,
+        })}
+      />
+      {name && name.length > 0 && (
+        <Typography
+          variant="h3"
+          className={clsx(classes.name, {
+            [classes.nameSelected]: selected,
+          })}
+        >
+          {name}
+        </Typography>
+      )}
+      <Typography variant="subtitle2" className={classes.title}>
+        {title}
+      </Typography>
+      {description && description.length > 0 && (
+        <Typography variant="caption" className={classes.description}>
+          {description}
+        </Typography>
+      )}
+      {link && link.url && (
+        <Button
+          href={link.url}
+          variant="outline"
+          size="small"
+          className={classes.link}
+        >
+          {link.title || link.url}
+        </Button>
+      )}
+    </Grid>
+  );
+}
+
+ListItem.propTypes = {
+  description: PropTypes.string,
+  image: PropTypes.shape({
+    description: PropTypes.string,
+    url: PropTypes.string.isRequired,
+  }).isRequired,
+  link: PropTypes.shape({
+    url: PropTypes.string.isRequired,
+    title: PropTypes.string,
+  }),
+  name: PropTypes.string,
+  onClick: PropTypes.func,
+  selected: PropTypes.bool,
+  title: PropTypes.string.isRequired,
+};
+ListItem.defaultProps = {
+  description: undefined,
+  link: undefined,
+  name: undefined,
+  onClick: undefined,
+  selected: false,
+};
+
+export default ListItem;

--- a/packages/core/src/ListItem/useStyles.js
+++ b/packages/core/src/ListItem/useStyles.js
@@ -1,0 +1,45 @@
+import { makeStyles } from "@material-ui/core/styles";
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    cursor: "pointer",
+    position: "relative",
+    height: (props) => props.height,
+    padding: 16,
+    width: "100%",
+    "&:after": {
+      backgroundColor: `${theme.palette.primary.main}`,
+      backgroundImage: (props) => `url("${props.image.url}")`,
+      backgroundPosition: "top left",
+      backgroundSize: "100% auto",
+      backgroundRepeat: "no-repeat",
+      bottom: 0,
+      content: '""',
+      left: 0,
+      mixBlendMode: "multiply",
+      opacity: 0.3,
+      position: "absolute",
+      right: 0,
+      top: 0,
+    },
+  },
+  picture: {
+    display: "none",
+    height: "auto",
+    width: "100%",
+  },
+  pictureSelected: {},
+  title: {
+    width: "100%",
+  },
+  link: {},
+  name: {
+    width: "100%",
+  },
+  nameSelected: {},
+  description: {
+    width: "100%",
+  },
+}));
+
+export default useStyles;

--- a/packages/core/src/ProfileList/Profile/index.js
+++ b/packages/core/src/ProfileList/Profile/index.js
@@ -39,7 +39,7 @@ function Profile({
       />
       {name && name.length > 0 && (
         <Typography
-          variant="body2"
+          variant="h3"
           className={clsx(classes.name, {
             [classes.nameSelected]: selected,
           })}
@@ -47,7 +47,7 @@ function Profile({
           {name}
         </Typography>
       )}
-      <Typography variant="body2" className={classes.title}>
+      <Typography variant="subtitle2" className={classes.title}>
         {title}
       </Typography>
       {description && description.length > 0 && (

--- a/packages/core/src/ProfileList/index.js
+++ b/packages/core/src/ProfileList/index.js
@@ -2,10 +2,12 @@
 import React, { useCallback, useEffect, useRef } from "react";
 import { PropTypes } from "prop-types";
 
+import clsx from "clsx";
+
 import { GridListTile } from "@material-ui/core";
 
 import GridList from "../ScrollableGridList";
-import Profile from "./Profile";
+import Profile from "../ListItem";
 import useStyles from "./useStyles";
 
 function ProfileList({
@@ -15,6 +17,8 @@ function ProfileList({
   onSelectedIndexChanged,
   lg,
   md,
+  profileClassCount,
+  profileClassPrefix,
   profiles,
   sm,
   xs,
@@ -64,8 +68,13 @@ function ProfileList({
             <Profile
               key={profile.title}
               classes={{
-                root: classes.profile,
+                root: clsx(classes.profile, {
+                  [`${profileClassPrefix}${
+                    index % profileClassCount
+                  }`]: profileClassCount,
+                }),
                 description: classes.profileDescription,
+                link: classes.profileLink,
                 name: classes.profileName,
                 nameSelected: classes.profileNameSelected,
                 picture: classes.profilePicture,
@@ -76,6 +85,7 @@ function ProfileList({
               onClick={onSelectedIndexChanged && (() => handleClick(index))}
               description={profile.description}
               image={profile.image}
+              link={profile.link}
               name={profile.name}
               title={profile.title}
               selected={selectedIndexProp === index}
@@ -94,11 +104,17 @@ ProfileList.propTypes = {
   lg: PropTypes.number,
   md: PropTypes.number,
   onSelectedIndexChanged: PropTypes.func,
+  profileClassCount: PropTypes.number,
+  profileClassPrefix: PropTypes.string,
   profiles: PropTypes.arrayOf(
     PropTypes.shape({
       description: PropTypes.string,
       image: PropTypes.shape({
         description: PropTypes.string,
+        url: PropTypes.string.isRequired,
+      }),
+      link: PropTypes.shape({
+        title: PropTypes.string,
         url: PropTypes.string.isRequired,
       }),
       name: PropTypes.string,
@@ -112,10 +128,12 @@ ProfileList.propTypes = {
 ProfileList.defaultProps = {
   cellHeight: 320,
   height: 370, // 23.125rem
-  selectedIndex: 0,
   lg: undefined,
   md: 4.3,
   onSelectedIndexChanged: undefined,
+  profileClassCount: 3,
+  profileClassPrefix: "profile-",
+  selectedIndex: 0,
   sm: undefined,
   xs: 1,
 };

--- a/packages/core/src/ProfileList/useStyles.js
+++ b/packages/core/src/ProfileList/useStyles.js
@@ -8,6 +8,7 @@ const useStyles = makeStyles(() => ({
   },
   profile: {},
   profileDescription: {},
+  profileLink: {},
   profileName: {},
   profileNameSelected: {},
   profilePicture: {},

--- a/packages/core/src/StoryList/index.js
+++ b/packages/core/src/StoryList/index.js
@@ -1,20 +1,26 @@
-import React from "react";
+import React, { useRef } from "react";
 import PropTypes from "prop-types";
 
-import { Grid, Typography, makeStyles } from "@material-ui/core";
+import clsx from "clsx";
 
-import List from "./StoryList";
+import { GridListTile, makeStyles } from "@material-ui/core";
+
+import GridList from "../ScrollableGridList";
+import Story from "../ListItem";
 
 const useStyles = makeStyles(() => ({
   root: {
-    flexGrow: 1,
-  },
-  heading: {
-    width: "100%",
-    marginBottom: "2rem",
+    zIndex: 1,
+    width: "calc(((100vw - 100%) / 2) + 100%)",
   },
   title: {},
   description: {},
+  story: {},
+  storyDescription: {},
+  storyLink: {},
+  storyName: {},
+  storyPicture: {},
+  storyTitle: {},
   stories: {},
   storiesGridList: {},
   storiesScrollBar: {},
@@ -22,79 +28,93 @@ const useStyles = makeStyles(() => ({
 
 function StoryList({
   cellHeight,
-  description,
   height,
   lg,
   md,
-  minHeight,
+  onClick,
   sm,
-  spacing,
+  storyClassCount,
+  storyClassPrefix,
   stories,
-  title,
   xs,
   ...props
 }) {
   const classes = useStyles(props);
+  const rootRef = useRef(null);
 
   if (!stories) {
     return null;
   }
   return (
-    <Grid container className={classes.root}>
-      <Grid
-        item
-        xs={12}
-        container
-        direction="row"
-        className={classes.heading}
-        justify="flex-start"
-        alignItems="center"
+    <div className={classes.root} ref={rootRef}>
+      <GridList
+        classes={{
+          root: classes.profiles,
+          gridList: classes.profilesGridList,
+          scrollBar: classes.profilesScrollBar,
+        }}
+        cellHeight={cellHeight}
+        height={height}
+        lg={lg}
+        md={md}
+        sm={sm}
+        xs={xs}
       >
-        <Grid item>
-          <Typography variant="h2" className={classes.title}>
-            {title}
-          </Typography>
-        </Grid>
-
-        <Grid item>
-          <Typography variant="body1" className={classes.description}>
-            {description}
-          </Typography>
-        </Grid>
-      </Grid>
-      <Grid item xs={12}>
-        <List
-          classes={{
-            root: classes.stories,
-            gridList: classes.storiesGridList,
-            scrollBar: classes.storiesScrollBar,
-          }}
-          cellHeight={cellHeight}
-          height={height}
-          lg={lg}
-          md={md}
-          minHeight={minHeight}
-          sm={sm}
-          spacing={spacing}
-          stories={stories}
-          xs={xs}
-        />
-      </Grid>
-    </Grid>
+        {stories.map((story, index) => (
+          <GridListTile key={story.id}>
+            <Story
+              key={story.title}
+              classes={{
+                root: clsx(classes.story, {
+                  [`${storyClassPrefix}${
+                    index % storyClassCount
+                  }`]: storyClassCount,
+                }),
+                description: classes.storyDescription,
+                link: classes.storyLink,
+                name: classes.storyName,
+                picture: classes.storyPicture,
+                title: classes.storyTitle,
+              }}
+              height={cellHeight}
+              onClick={() => onClick && onClick(index)}
+              description={story.description}
+              image={story.image}
+              link={story.link}
+              name={story.name}
+              title={story.title}
+            />
+          </GridListTile>
+        ))}
+      </GridList>
+    </div>
   );
 }
 
 StoryList.propTypes = {
   cellHeight: PropTypes.number,
-  description: PropTypes.string.isRequired,
   height: PropTypes.number,
   lg: PropTypes.number,
   md: PropTypes.number,
-  minHeight: PropTypes.number,
+  onClick: PropTypes.func,
+  storyClassCount: PropTypes.number,
+  storyClassPrefix: PropTypes.string,
+  stories: PropTypes.arrayOf(
+    PropTypes.shape({
+      description: PropTypes.string,
+      image: PropTypes.shape({
+        description: PropTypes.string,
+        url: PropTypes.string.isRequired,
+      }),
+      link: PropTypes.shape({
+        title: PropTypes.string,
+        url: PropTypes.string.isRequired,
+      }),
+      name: PropTypes.string,
+      title: PropTypes.string,
+    })
+  ).isRequired,
   sm: PropTypes.number,
-  spacing: PropTypes.number,
-  stories: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
-  title: PropTypes.string.isRequired,
   xs: PropTypes.number,
 };
 
@@ -103,9 +123,10 @@ StoryList.defaultProps = {
   height: 370, // 23.125rem
   lg: undefined,
   md: 3.3,
-  minHeight: undefined,
+  onClick: undefined,
   sm: undefined,
-  spacing: undefined,
+  storyClassCount: 3,
+  storyClassPrefix: "story-",
   xs: 1.3,
 };
 

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -2,6 +2,7 @@
 export { default as A } from "./A";
 export { default as DocumentsAndDatasets } from "./DocumentsAndDatasets";
 export { default as Footer } from "./Footer";
+export { default as ListItem } from "./ListItem";
 export { default as Layout } from "./Layout";
 export { default as ProfileList } from "./ProfileList";
 export { default as RichTypography } from "./RichTypography";

--- a/stories/components.stories.js
+++ b/stories/components.stories.js
@@ -9,7 +9,7 @@ import { makeStyles } from "@material-ui/core/styles";
 
 import DescriptionOutlinedIcon from "@material-ui/icons/DescriptionOutlined";
 import NavigationButton from "./NavigationButton";
-import { getProfiles, fromTimestamp, useStories } from "./utils";
+import { getProfiles, useStories } from "./utils";
 
 import imgHighlight from "./assets/images/illo-02.png";
 
@@ -107,21 +107,17 @@ storiesOf("Components|Story List", module).add("Default", () => {
   );
   const stories = foundStories.map((story) => ({
     ...story,
-    createdAt: fromTimestamp(story.createdAt),
+    description: story.subtitle,
+    link: { url: story.uniqueSlug, title: "Learn More" },
     image: {
       url: `https://cdn-images-1.medium.com/max/480/${story.virtuals.previewImage.imageId}`,
     },
   }));
 
   return (
-    <StoryList
-      description="View and explore how we visualise Kenya’s budget data to show how much money each county has received from the national government, and how the money is allocated and utilized based on each county’spriorities"
-      md={3.3}
-      spacing={0}
-      stories={stories}
-      title="Showcase"
-      xs={1.3}
-    />
+    <div style={{ margin: "0 auto", width: "80%", overflow: "visible" }}>
+      <StoryList md={3.3} spacing={0} stories={stories} xs={1.3} />
+    </div>
   );
 });
 


### PR DESCRIPTION
## Description

Introduce `ListItem` that works for both `StoryList` and `ProfileList`:

 - Optional `name` (`H3`)
 - Optional `link` (`Button variant="outline" size="small"`)

Other props being equal. Also `StoryList` and `ProfileList` now include `story-X/profile-X` classes for each story (with `X` being 0 up to `storyClassCount/profileClassCount` prop. This will allow for customization of these classes downstream.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Screenshots

![S](https://user-images.githubusercontent.com/1779590/80377188-9a6b6e00-88a3-11ea-8c3c-917521666bcb.png)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
