### PR TITLE
[HotFix] Fix initial scroll to ProfileList

### DIFF
--- a/packages/core/src/ProfileList/index.js
+++ b/packages/core/src/ProfileList/index.js
@@ -20,6 +20,7 @@ function ProfileList({
   profileClassCount,
   profileClassPrefix,
   profiles,
+  scrollOnSelectedIndexChange: scrollOnSelectedIndexChangeProp,
   selectedIndex: selectedIndexProp,
   sm,
   xs,
@@ -28,12 +29,12 @@ function ProfileList({
   const classes = useStyles(props);
   const rootRef = useRef(null);
   const handleClick = useCallback(
-    (selectedIndex) => {
+    (selectedIndex, scrollOnSelectedIndexChange) => {
       const profileEls = rootRef.current.getElementsByClassName(
         classes.profile
       );
       const profileEl = profileEls[selectedIndex];
-      if (profileEl) {
+      if (profileEl && scrollOnSelectedIndexChange) {
         profileEl.scrollIntoView({ behavior: "smooth" });
       }
       if (onSelectedIndexChanged) {
@@ -43,8 +44,8 @@ function ProfileList({
     [classes.profile, onSelectedIndexChanged]
   );
   useEffect(() => {
-    handleClick(selectedIndexProp);
-  }, [handleClick, selectedIndexProp]);
+    handleClick(selectedIndexProp, scrollOnSelectedIndexChangeProp);
+  }, [handleClick, scrollOnSelectedIndexChangeProp, selectedIndexProp]);
 
   if (!profiles.length) {
     return null;
@@ -67,7 +68,6 @@ function ProfileList({
         {profiles.map((profile, index) => (
           <GridListTile key={profile.id}>
             <Profile
-              key={profile.title}
               classes={{
                 root: clsx(classes.profile, {
                   [`${profileClassPrefix}${
@@ -83,7 +83,9 @@ function ProfileList({
                 title: classes.profileTitle,
               }}
               height={cellHeight}
-              onClick={onSelectedIndexChanged && (() => handleClick(index))}
+              onClick={
+                onSelectedIndexChanged && (() => handleClick(index, true))
+              }
               description={profile.description}
               image={profile.image}
               link={profile.link}
@@ -123,6 +125,7 @@ ProfileList.propTypes = {
       title: PropTypes.string,
     })
   ).isRequired,
+  scrollOnSelectedIndexChange: PropTypes.bool,
   selectedIndex: PropTypes.number,
   sm: PropTypes.number,
   xs: PropTypes.number,
@@ -137,6 +140,7 @@ ProfileList.defaultProps = {
   onSelectedIndexChanged: undefined,
   profileClassCount: 3,
   profileClassPrefix: "profile-",
+  scrollOnSelectedIndexChange: false,
   selectedIndex: 0,
   sm: undefined,
   xs: 1,

--- a/packages/core/src/StoryList/index.js
+++ b/packages/core/src/StoryList/index.js
@@ -47,7 +47,6 @@ function StoryList({
         {stories.map((story, index) => (
           <GridListTile key={story.id}>
             <Story
-              key={story.title}
               classes={{
                 root: clsx(classes.story, {
                   [`${storyClassPrefix}${

--- a/stories/components.stories.js
+++ b/stories/components.stories.js
@@ -76,6 +76,7 @@ storiesOf("Components|Profile List", module)
             }}
             onSelectedIndexChanged={handleSelectedIndexChanged}
             profiles={profiles}
+            scrollOnSelectedIndexChange
             selectedIndex={selectedIndex}
           />
         </Grid>


### PR DESCRIPTION
## Description

- [x] Make `scrollIntoView` used in `ProfileList` configurable via prop, and
- [x] Lint and fix code.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Screenshots

N/A

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
