### PR TITLE
[HotFix] Documents and Datasets

### DIFF
--- a/packages/core/src/DocumentsAndDatasets/Content.js
+++ b/packages/core/src/DocumentsAndDatasets/Content.js
@@ -5,20 +5,20 @@ import { Button, Grid, makeStyles } from "@material-ui/core";
 
 import RichTypography from "../RichTypography";
 
-const useStyles = makeStyles(() => ({
+const useStyles = makeStyles(({ breakpoints, typography }) => ({
   root: {
-    flexGrow: 1,
-    textAlign: "left",
-    marginTop: "1rem",
+    flexWrap: "nowrap",
+    [breakpoints.up("md")]: {
+      flexWrap: "wrap",
+    },
   },
   contentType: {
-    paddingTop: "1rem",
-    paddingBottom: "3rem",
+    paddingTop: typography.pxToRem(14),
   },
-  description: {},
-  icon: {
-    paddingTop: "1rem",
+  description: {
+    paddingTop: typography.pxToRem(24),
   },
+  icon: {},
   link: {},
 }));
 
@@ -27,12 +27,10 @@ function Content({ children, contentType, description, icon, link, ...props }) {
 
   return (
     <Grid container className={classes.root}>
-      {icon && (
-        <Grid item xs={2} sm={1} md={12} className={classes.icon}>
-          {icon}
-        </Grid>
-      )}
-      <Grid item xs={icon ? 10 : 12} sm={icon ? 11 : 12} md={12} container>
+      <Grid item xs="auto" md={12} className={classes.icon}>
+        {icon}
+      </Grid>
+      <Grid item xs="auto" md={12} container>
         <Grid item xs={12}>
           <RichTypography
             variant="subtitle2"
@@ -72,7 +70,7 @@ Content.propTypes = {
   children: PropTypes.node,
   contentType: PropTypes.string.isRequired,
   description: PropTypes.string,
-  icon: PropTypes.node,
+  icon: PropTypes.node.isRequired,
   link: PropTypes.shape({
     href: PropTypes.string.isRequired,
     label: PropTypes.string,
@@ -82,7 +80,6 @@ Content.propTypes = {
 Content.defaultProps = {
   children: undefined,
   description: undefined,
-  icon: undefined,
   link: { href: "#", label: "View More" },
 };
 

--- a/packages/core/src/DocumentsAndDatasets/Desktop/index.js
+++ b/packages/core/src/DocumentsAndDatasets/Desktop/index.js
@@ -1,0 +1,115 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+import { Grid } from "@material-ui/core";
+
+import Content from "../Content";
+import RichTypography from "../../RichTypography";
+import Section from "../../Section";
+import useStyles from "../useStyles";
+
+function DocumentsAndDatasets({
+  children,
+  datasets,
+  documents,
+  subtitle,
+  title,
+  ...props
+}) {
+  const classes = useStyles(props);
+
+  return (
+    <div className={classes.root}>
+      <Section classes={{ root: classes.section }}>
+        <Grid container className={classes.container}>
+          <Grid item md={5} className={classes.highlight}>
+            {children}
+          </Grid>
+          <Grid
+            item
+            md={7}
+            container
+            direction="column"
+            className={classes.content}
+          >
+            <Grid item className={classes.heading}>
+              <RichTypography
+                variant="h2"
+                color="textSecondary"
+                className={classes.title}
+              >
+                {title}
+              </RichTypography>
+              {subtitle && (
+                <RichTypography
+                  variant="subtitle1"
+                  color="textSecondary"
+                  className={classes.subtitle}
+                >
+                  {subtitle}
+                </RichTypography>
+              )}
+            </Grid>
+            <Grid
+              item
+              container
+              direction
+              justify="space-between"
+              className={classes.contents}
+            >
+              <Grid item md={5} className={classes.contentsDocuments}>
+                <Content
+                  {...documents}
+                  classes={{
+                    root: classes.documents,
+                    contentType: classes.documentsContentType,
+                    description: classes.documentsDescription,
+                    icon: classes.documentsIcon,
+                    link: classes.documentsLink,
+                  }}
+                />
+              </Grid>
+              <Grid item md={5} className={classes.contentsDatasets}>
+                <Content
+                  {...datasets}
+                  classes={{
+                    root: classes.datasets,
+                    contentType: classes.datasetsContentType,
+                    description: classes.datasetsDescription,
+                    icon: classes.datasetsIcon,
+                    link: classes.datasetsLink,
+                  }}
+                />
+              </Grid>
+            </Grid>
+          </Grid>
+        </Grid>
+      </Section>
+    </div>
+  );
+}
+
+DocumentsAndDatasets.propTypes = {
+  children: PropTypes.node,
+  datasets: PropTypes.shape({
+    icon: PropTypes.node,
+  }),
+  documents: PropTypes.shape({
+    icon: PropTypes.node,
+  }),
+  subtitle: PropTypes.string,
+  title: PropTypes.string.isRequired,
+};
+
+DocumentsAndDatasets.defaultProps = {
+  children: null,
+  datasets: {
+    contentType: "Datasets",
+  },
+  documents: {
+    contentType: "Documents",
+  },
+  subtitle: undefined,
+};
+
+export default DocumentsAndDatasets;

--- a/packages/core/src/DocumentsAndDatasets/Mobile/index.js
+++ b/packages/core/src/DocumentsAndDatasets/Mobile/index.js
@@ -1,0 +1,107 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+import clsx from "clsx";
+
+import { Grid } from "@material-ui/core";
+
+import Content from "../Content";
+import RichTypography from "../../RichTypography";
+import Section from "../../Section";
+import useStyles from "../useStyles";
+
+function MobileDocumentsAndDatasets({
+  children,
+  datasets,
+  documents,
+  subtitle,
+  title,
+  ...props
+}) {
+  const classes = useStyles(props);
+
+  return (
+    <div className={clsx(classes.root)}>
+      <Grid container className={classes.container}>
+        <Grid item xs={12} className={classes.highlight}>
+          {children}
+        </Grid>
+        <Grid item xs={12} container className={classes.content}>
+          <Grid item xs={12} className={classes.heading}>
+            <Section classes={{ root: classes.section }}>
+              <RichTypography
+                variant="h2"
+                color="textSecondary"
+                className={classes.title}
+              >
+                {title}
+              </RichTypography>
+              <RichTypography
+                variant="subtitle1"
+                color="textSecondary"
+                className={classes.subtitle}
+              >
+                {subtitle}
+              </RichTypography>
+            </Section>
+          </Grid>
+          <Grid item xs={12} container className={classes.contents}>
+            <Grid item xs={12} className={classes.contentsDocuments}>
+              <Section classes={{ root: classes.section }}>
+                <Content
+                  {...documents}
+                  classes={{
+                    root: classes.documents,
+                    contentType: classes.documentsContentType,
+                    description: classes.documentsDescription,
+                    icon: classes.documentsIcon,
+                    link: classes.documentsLink,
+                  }}
+                />
+              </Section>
+            </Grid>
+            <Grid item xs={12} className={classes.contentsDatasets}>
+              <Section classes={{ root: classes.section }}>
+                <Content
+                  {...datasets}
+                  classes={{
+                    root: classes.datasets,
+                    contentType: classes.datasetsContentType,
+                    description: classes.datasetsDescription,
+                    icon: classes.datasetsIcon,
+                    link: classes.datasetsLink,
+                  }}
+                />
+              </Section>
+            </Grid>
+          </Grid>
+        </Grid>
+      </Grid>
+    </div>
+  );
+}
+
+MobileDocumentsAndDatasets.propTypes = {
+  children: PropTypes.node,
+  datasets: PropTypes.shape({
+    icon: PropTypes.node,
+  }),
+  documents: PropTypes.shape({
+    icon: PropTypes.node,
+  }),
+  subtitle: PropTypes.string,
+  title: PropTypes.string.isRequired,
+};
+
+MobileDocumentsAndDatasets.defaultProps = {
+  children: null,
+  datasets: {
+    contentType: "Datasets",
+  },
+  documents: {
+    contentType: "Documents",
+  },
+  subtitle: undefined,
+};
+
+export default MobileDocumentsAndDatasets;

--- a/packages/core/src/DocumentsAndDatasets/index.js
+++ b/packages/core/src/DocumentsAndDatasets/index.js
@@ -1,134 +1,21 @@
 import React from "react";
-import PropTypes from "prop-types";
 
-import clsx from "clsx";
+import { useMediaQuery, useTheme } from "@material-ui/core";
 
-import { Grid, Hidden } from "@material-ui/core";
+import Mobile from "./Mobile";
+import Desktop from "./Desktop";
 
-import Content from "./Content";
-import RichTypography from "../RichTypography";
-import Section from "../Section";
-import useStyles from "./useStyles";
+/**
+ * Biggest difference between Mobile & Desktop is how background and Section
+ * are handled.
+ *
+ * @param {*} props
+ */
+function DocumentsAndDatasets(props) {
+  const theme = useTheme();
+  const isDesktop = useMediaQuery(theme.breakpoints.up("md"));
+  const Component = isDesktop ? Desktop : Mobile;
 
-function DocumentsAndDatasets({
-  children,
-  datasets,
-  description,
-  documents,
-  title,
-  ...props
-}) {
-  const classes = useStyles(props);
-
-  return (
-    <div className={classes.root}>
-      <Section classes={{ root: classes.section }}>
-        <Grid container className={classes.background}>
-          <Grid item xs={12} md={5} className={classes.highlight}>
-            {children}
-          </Grid>
-          <Grid
-            item
-            md={7}
-            container
-            implementation="css"
-            smDown
-            component={Hidden}
-          >
-            <Grid item md={6} className={classes.backgroundDocuments} />
-            <Grid item md={6} className={classes.backgroundDatasets} />
-          </Grid>
-        </Grid>
-        <Grid container className={classes.content}>
-          <Grid item md={5} implementation="css" smDown component={Hidden} />
-          <Grid item xs={12} md={7} container justify="space-between">
-            <Grid item xs={12} className={classes.contentHeading}>
-              <RichTypography
-                variant="h2"
-                color="textSecondary"
-                className={classes.title}
-              >
-                {title}
-              </RichTypography>
-              <RichTypography
-                variant="subtitle1"
-                color="textSecondary"
-                className={classes.description}
-              >
-                {description}
-              </RichTypography>
-            </Grid>
-          </Grid>
-          <Grid item md={5} implementation="css" smDown component={Hidden} />
-          <Grid
-            item
-            xs={12}
-            md={3}
-            className={clsx(
-              classes.backgroundDocuments,
-              classes.contentDocuments
-            )}
-          >
-            <Content
-              {...documents}
-              classes={{
-                root: classes.documents,
-                contentType: classes.documentsContentType,
-                description: classes.documentsDescription,
-                icon: classes.documentsIcon,
-                link: classes.documentsLink,
-              }}
-            />
-          </Grid>
-          <Grid item md={1} implementation="css" smDown component={Hidden} />
-          <Grid
-            item
-            xs={12}
-            md={3}
-            className={clsx(
-              classes.backgroundDatasets,
-              classes.contentDatasets
-            )}
-          >
-            <Content
-              {...datasets}
-              classes={{
-                root: classes.datasets,
-                contentType: classes.datasetsContentType,
-                description: classes.datasetsDescription,
-                icon: classes.datasetsIcon,
-                link: classes.datasetsLink,
-              }}
-            />
-          </Grid>
-        </Grid>
-      </Section>
-    </div>
-  );
+  return <Component {...props} />;
 }
-
-DocumentsAndDatasets.propTypes = {
-  children: PropTypes.node,
-  datasets: PropTypes.shape({
-    icon: PropTypes.node,
-  }),
-  description: PropTypes.string,
-  documents: PropTypes.shape({
-    icon: PropTypes.node,
-  }),
-  title: PropTypes.string,
-};
-
-DocumentsAndDatasets.defaultProps = {
-  children: null,
-  datasets: {
-    contentType: "Datasets",
-  },
-  description: undefined,
-  documents: {
-    contentType: "Documents",
-  },
-  title: undefined,
-};
-
 export default DocumentsAndDatasets;

--- a/packages/core/src/DocumentsAndDatasets/useStyles.js
+++ b/packages/core/src/DocumentsAndDatasets/useStyles.js
@@ -2,50 +2,41 @@ import { makeStyles } from "@material-ui/core/styles";
 
 const useStyles = makeStyles(({ breakpoints, palette }) => ({
   root: {
-    flexGrow: 1,
     backgroundColor: palette.primary.main,
+    [breakpoints.up("md")]: {
+      backgroundColor: palette.primary.main,
+      background: `linear-gradient(to right, ${palette.primary.main} 0%, ${palette.primary.main} 50%, rgba(255, 255, 255, 0.1) 50%, rgba(255, 255, 255, 0.1) 100%);`,
+    },
   },
-  section: {
-    position: "relative",
-  },
-  background: {},
-  backgroundDatasets: {
-    background: "rgba(255, 255, 255, 0.1)",
-  },
-  backgroundDocuments: {},
+  section: {},
+  container: {},
   content: {
     [breakpoints.up("md")]: {
-      position: "absolute",
-      top: 0,
+      background: `linear-gradient(to right, ${palette.primary.main} 0%, ${palette.primary.main} 50%, transparent 50%, transparent 100%);`,
     },
   },
-  contentDatasets: {
+  contents: {},
+  contentsDatasets: {
+    backgroundColor: "rgba(255, 255, 255, 0.1)",
     [breakpoints.up("md")]: {
-      background: "inherit",
+      background: "unset",
     },
   },
-  contentDocuments: {
-    [breakpoints.up("md")]: {
-      background: "inherit",
-    },
-  },
-  contentHeading: {
-    marginTop: "5rem",
-  },
+  contentsDocuments: {},
   datasets: {},
   datasetsContentTitle: {},
   datasetsDescription: {},
   datasetsIcon: {},
   datasetsLink: {},
-  description: {
-    marginTop: "1rem",
-  },
+  description: {},
   documents: {},
   documentsContentTitle: {},
   documentsDescription: {},
   documentsIcon: {},
   documentsLink: {},
+  heading: {},
   highlight: {},
+  subtitle: {},
   title: {},
 }));
 

--- a/stories/components.stories.js
+++ b/stories/components.stories.js
@@ -131,6 +131,10 @@ storiesOf("Components|DocumentsAndDatasets", module)
   .add("Default", () =>
     React.createElement(() => {
       const classes = makeStyles(({ breakpoints }) => ({
+        section: {
+          margin: "0 auto",
+          width: "90%",
+        },
         img: {
           width: "100%",
           background: `transparent url(${imgHighlight}) 50% 50% no-repeat`,
@@ -152,12 +156,13 @@ storiesOf("Components|DocumentsAndDatasets", module)
           marginTop: "2rem",
         },
       }))();
+
       return (
         <div>
           <DocumentsAndDatasets
             title={text("title", "Featured Research")}
-            description={text(
-              "description",
+            subtitle={text(
+              "subtitle",
               "Get access to the best original scientific and medical research by African experts who understand local context."
             )}
             datasets={{
@@ -173,6 +178,7 @@ storiesOf("Components|DocumentsAndDatasets", module)
               icon: <DescriptionIcon fontSize="large" />,
             }}
             classes={{
+              section: classes.section,
               datasetsLink: classes.datasetsLink,
               documentsLink: classes.documentsLink,
             }}


### PR DESCRIPTION
## Description

Since different backgrounds and use of `Section` is required for Mobile and Desktop views, lets go back to basics and have separate components for each of these views

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## Mobile Screenshots

![Screenshot_2020-05-11 Components DocumentsAndDatasets - Default ⋅ Storybook(1)](https://user-images.githubusercontent.com/1779590/81542876-035fe500-937e-11ea-92a1-91dbdcd2a896.png)

## Desktop Screenshots

![Screenshot_2020-05-11 Components DocumentsAndDatasets - Default ⋅ Storybook](https://user-images.githubusercontent.com/1779590/81542847-f511c900-937d-11ea-9aa2-b183a933cb8f.png)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
