### PR TITLE
[HotFix] oneOfType requires an array

### DIFF
--- a/packages/core/src/ScrollBar/index.js
+++ b/packages/core/src/ScrollBar/index.js
@@ -52,7 +52,7 @@ function ScrollBar({ autoHide, children, height, ...props }) {
 ScrollBar.propTypes = {
   autoHide: PropTypes.bool,
   children: PropTypes.node,
-  height: PropTypes.oneOfType(PropTypes.number, PropTypes.string).isRequired, // in px
+  height: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired, // in px
   list: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
 };
 

--- a/packages/core/src/ScrollableGridList/index.js
+++ b/packages/core/src/ScrollableGridList/index.js
@@ -94,7 +94,7 @@ ScrollableGridList.propTypes = {
   autoHide: PropTypes.bool,
   cellHeight: PropTypes.number,
   children: PropTypes.node,
-  height: PropTypes.oneOfType(PropTypes.number, PropTypes.string).isRequired, // in px
+  height: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired, // in px
   lg: PropTypes.number,
   md: PropTypes.number,
   sm: PropTypes.number,

--- a/packages/core/src/StoryList/StoryList.js
+++ b/packages/core/src/StoryList/StoryList.js
@@ -52,7 +52,7 @@ function StoryList({
 
 StoryList.propTypes = {
   cellHeight: PropTypes.number.isRequired,
-  height: PropTypes.oneOfType(PropTypes.number, PropTypes.string), // in px
+  height: PropTypes.oneOfType([PropTypes.number, PropTypes.string]), // in px
   lg: PropTypes.number,
   md: PropTypes.number,
   minHeight: PropTypes.number,


### PR DESCRIPTION
## Description

`oneOfType` requires an array as argument and not individual types.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

![Screenshot from 2020-06-23 09-39-32](https://user-images.githubusercontent.com/1779590/85369468-d46c8f80-b535-11ea-87f8-a7ff4b3c2c9a.png)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
