### PR TITLE
[Hot fix] Initiative Style Name Overide

### DIFF
--- a/packages/core/src/Footer/About/Initiative.js
+++ b/packages/core/src/Footer/About/Initiative.js
@@ -8,7 +8,7 @@ import RichTypography from "../../RichTypography";
 function Initiative({ children, variant, ...props }) {
   const classes = useStyles(props);
   return (
-    <RichTypography variant={variant} className={classes.initiative}>
+    <RichTypography variant={variant} className={classes.aboutInitiative}>
       {children}
     </RichTypography>
   );

--- a/packages/core/src/Footer/Initiative.js
+++ b/packages/core/src/Footer/Initiative.js
@@ -6,15 +6,15 @@ import RichTypography from "../RichTypography";
 
 import useStyles from "./useStyles";
 
-function Initiative({ logo, children, ...props }) {
+function Initiative({ image, url, children, ...props }) {
   const classes = useStyles(props);
 
   return (
     <div className={classes.root}>
-      <A href={logo.url}>
+      <A href={url}>
         <img
-          src={logo.image.url}
-          alt={logo.image.alt}
+          src={image.url}
+          alt={image.alt}
           className={classes.supporterLogo}
         />
       </A>
@@ -27,13 +27,11 @@ function Initiative({ logo, children, ...props }) {
 
 Initiative.propTypes = {
   children: PropTypes.node.isRequired,
-  logo: PropTypes.shape({
-    image: PropTypes.shape({
-      alt: PropTypes.string.isRequired,
-      url: PropTypes.string.isRequired,
-    }).isRequired,
+  image: PropTypes.shape({
+    alt: PropTypes.string.isRequired,
     url: PropTypes.string.isRequired,
   }).isRequired,
+  url: PropTypes.string.isRequired,
 };
 
 export default Initiative;

--- a/packages/core/src/Footer/PrimaryFooter.js
+++ b/packages/core/src/Footer/PrimaryFooter.js
@@ -35,7 +35,7 @@ function PrimaryFooter({
               classes={{
                 root: classes.about,
                 about: classes.aboutAbout,
-                initiative: classes.Initiative,
+                initiative: classes.aboutInitiative,
               }}
             >
               {about.about}
@@ -54,7 +54,7 @@ function PrimaryFooter({
           </Grid>
           <Grid item xs={12} md={2} className={classes.initiative}>
             <div className={classes.project}>
-              <Initiative {...options.initiativeLogo} logo={initiativeLogo}>
+              <Initiative {...options.initiativeLogo} {...initiativeLogo}>
                 {about.initiative}
               </Initiative>
             </div>

--- a/packages/core/src/Footer/useStyles.js
+++ b/packages/core/src/Footer/useStyles.js
@@ -10,15 +10,11 @@ const useStyles = makeStyles(
       display: "block",
     },
     aboutAbout: {},
-    initiative: {
+    aboutInitiative: {
       display: "none",
       [breakpoints.up("md")]: {
         display: "block",
         marginTop: "1.5rem",
-      },
-      order: 2,
-      [breakpoints.up("md")]: {
-        order: 5,
       },
     },
     divider: {
@@ -80,6 +76,12 @@ const useStyles = makeStyles(
       [breakpoints.up("md")]: {
         marginTop: 0,
         order: 4,
+      },
+    },
+    initiative: {
+      order: 2,
+      [breakpoints.up("md")]: {
+        order: 5,
       },
     },
     copyright: {

--- a/stories/footer.stories.js
+++ b/stories/footer.stories.js
@@ -251,7 +251,7 @@ storiesOf("Components/Footer", module)
 
     return (
       <FooterInitiativeLogo
-        logo={INITIATIVE_LOGO}
+        {...INITIATIVE_LOGO}
         classes={{ section: classes.section }}
       >
         {ABOUT.initative}


### PR DESCRIPTION
## Description

Rename `about/initiative`'s classname from `initiative` to `aboutInitiative` to avoid clashing with  `InitiativeLogo` component

Fixes # (NA)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Screenshots

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
